### PR TITLE
Fix random padding failures

### DIFF
--- a/src/main/java/com/mountainminds/three4j/PlainMessage.java
+++ b/src/main/java/com/mountainminds/three4j/PlainMessage.java
@@ -55,7 +55,9 @@ public abstract class PlainMessage {
 		try (var buffer = new ByteArrayOutputStream(); var out = new DataOutputStream(buffer)) {
 			out.write(getType());
 			encode(out);
-			int padding = 0xFF & Bytes.secureRandom(1)[0];
+			// add random padding of 1 - 255 bytes (PKCS#7 style)
+			int padding = Math.max(1, 0xFF & Bytes.secureRandom(1)[0]);
+			System.out.println(padding);
 			for (int i = 0; i < padding; i++) {
 				out.write(padding);
 			}


### PR DESCRIPTION
PKCS#7 padding adds a random number of 1-255 bytes. Adding 0 bytes
breaks the removal of the padding.