### PR TITLE
Add utility method to derive public key from a private key

### DIFF
--- a/src/test/java/com/mountainminds/three4j/KeyEncoderTest.java
+++ b/src/test/java/com/mountainminds/three4j/KeyEncoderTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Mountainminds GmbH & Co. KG
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ *******************************************************************************/
+package com.mountainminds.three4j;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class KeyEncoderTest {
+
+	@Test
+	public void getPublicKey_should_return_corresponding_public_key() {
+		var pair = KeyGenerator.generate();
+		var publicKey = KeyEncoder.getPublicKey(pair.getPrivate());
+		assertEquals(pair.getPublic(), publicKey);
+	}
+
+}


### PR DESCRIPTION
EC public keys can be derived from the corresponding private key. This
utility allows applications not storing the public key in addition to
the private key.